### PR TITLE
Add process file name option.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,12 @@ e2etest_setup:
 	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_k.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_k.pid --config /etc/td-agent/td-agent_k.conf
 	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_l.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_l.pid --config /etc/td-agent/td-agent_l.conf
 	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_m.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_m.pid --config /etc/td-agent/td-agent_m.conf
+	/opt/td-agent/embedded/bin/fluentd --use-v1-config --config /etc/td-agent/td-agent_from_fluent.conf --no-supervisor &
+	/usr/sbin/td-agent --use-v1-config --config /etc/td-agent/td-agent_from_td_agent.conf --no-supervisor &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug -web.listen-address=19256 -fluentd.process_name_prefix=foo &
+	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug -web.listen-address=29256 -fluentd.process_file_name=fluentd &
+	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug -web.listen-address=39256 -fluentd.process_file_name=td-agent &
 
 	# Wait for td-agent_exporter to start up
 	sleep 3

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Name     | Description | Default | note
 ---------|-------------|----|----
 web.listen-address | Address on which to expose metrics and web interface | 9256 |
 web.telemetry-path | Path under which to expose metrics | /metrics |
+fluentd.process_file_name | Pfluentd's process file name. | ruby | For example, td-agent is being executed from supervisord, specify "td-agent".
 fluentd.process_name_prefix | fluentd's process_name prefix | | see also: [Fluentd official documentation](http://docs.fluentd.org/v0.12/articles/config-file#processname)
 log.level | Log level | info |
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Name     | Description | Default | note
 ---------|-------------|----|----
 web.listen-address | Address on which to expose metrics and web interface | 9256 |
 web.telemetry-path | Path under which to expose metrics | /metrics |
-fluentd.process_file_name | fluentd's process file name. | ruby | For example, td-agent is being executed from supervisord, specify "td-agent".
+fluentd.process_file_name | fluentd's process file name. | ruby | For example, td-agent is being executed from /opt/td-agent/embedded/bin/fluentd, specify "fluentd".
 fluentd.process_name_prefix | fluentd's process_name prefix | | see also: [Fluentd official documentation](http://docs.fluentd.org/v0.12/articles/config-file#processname)
 log.level | Log level | info |
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Name     | Description | Default | note
 ---------|-------------|----|----
 web.listen-address | Address on which to expose metrics and web interface | 9256 |
 web.telemetry-path | Path under which to expose metrics | /metrics |
-fluentd.process_file_name | Pfluentd's process file name. | ruby | For example, td-agent is being executed from supervisord, specify "td-agent".
+fluentd.process_file_name | fluentd's process file name. | ruby | For example, td-agent is being executed from supervisord, specify "td-agent".
 fluentd.process_name_prefix | fluentd's process_name prefix | | see also: [Fluentd official documentation](http://docs.fluentd.org/v0.12/articles/config-file#processname)
 log.level | Log level | info |
 

--- a/_test/td-agent_from_fluent.conf
+++ b/_test/td-agent_from_fluent.conf
@@ -1,0 +1,12 @@
+<system>
+  process_name from_fluentd
+</system>
+
+<match debug.**>
+  @type stdout
+</match>
+
+<source>
+  @type forward
+  port 32001
+</source>

--- a/_test/td-agent_from_td_agent.conf
+++ b/_test/td-agent_from_td_agent.conf
@@ -1,0 +1,12 @@
+<system>
+  process_name from_td_agent
+</system>
+
+<match debug.**>
+  @type stdout
+</match>
+
+<source>
+  @type forward
+  port 32002
+</source>

--- a/td-agent_exporter.go
+++ b/td-agent_exporter.go
@@ -20,8 +20,8 @@ var (
 	// command line parameters
 	listenAddress     = flag.String("web.listen-address", "9256", "Address on which to expose metrics and web interface.")
 	metricsPath       = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-	processNamePrefix = flag.String("fluentd.process_name_prefix", "", "fluentd's process_name prefix.")
 	processFileName   = flag.String("fluentd.process_file_name", "ruby", "fluentd's process file name.")
+	processNamePrefix = flag.String("fluentd.process_name_prefix", "", "fluentd's process_name prefix.")
 
 	processNameRegex       = regexp.MustCompile(`\s/usr/sbin/td-agent\s*`)
 	tdAgentPathRegex       = regexp.MustCompile("\\s" + strings.Replace(tdAgentLaunchCommand, " ", "\\s", -1) + "(.+)?\\s*")

--- a/td-agent_exporter.go
+++ b/td-agent_exporter.go
@@ -21,6 +21,7 @@ var (
 	listenAddress     = flag.String("web.listen-address", "9256", "Address on which to expose metrics and web interface.")
 	metricsPath       = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	processNamePrefix = flag.String("fluentd.process_name_prefix", "", "fluentd's process_name prefix.")
+	processFileName   = flag.String("fluentd.process_file_name", "ruby", "fluentd's process file name.")
 
 	processNameRegex       = regexp.MustCompile(`\s/usr/sbin/td-agent\s*`)
 	tdAgentPathRegex       = regexp.MustCompile("\\s" + strings.Replace(tdAgentLaunchCommand, " ", "\\s", -1) + "(.+)?\\s*")
@@ -161,7 +162,7 @@ func (e *Exporter) resolveTdAgentId() (map[string]string, error) {
 }
 
 func (e *Exporter) execPsCommand() (string, error) {
-	ps, err := exec.Command("ps", "-C", "ruby", "-f").Output()
+	ps, err := exec.Command("ps", "-C", *processFileName, "-f").Output()
 	if err != nil {
 		log.Error(err)
 		return "", err

--- a/td-agent_exporter_test.go
+++ b/td-agent_exporter_test.go
@@ -237,6 +237,14 @@ func TestE2EWithoutProcessNamePrefix(t *testing.T) {
 		if !regexp.MustCompile("td_agent_up 14").MatchString(metrics) {
 			t.Error("td_agent_up doesn't match")
 		}
+
+		// Different process file name processes are not mathed.
+		if regexp.MustCompile(`td_agent_cpu_time\{id="from_fluentd"\} `).MatchString(metrics) {
+			t.Error("Process from /opt/td-agent/embedded/bin/fluentd shouldn't match")
+		}
+		if regexp.MustCompile(`td_agent_cpu_time\{id="from_td-agent"\} `).MatchString(metrics) {
+			t.Error("Process from /usr/sbin/td-agent shouldn't match")
+		}
 	}
 }
 
@@ -278,6 +286,74 @@ func TestE2EWithProcessNamePrefix(t *testing.T) {
 
 		// td_agent_up
 		if !regexp.MustCompile("td_agent_up 13").MatchString(metrics) {
+			t.Error("td_agent_up doesn't match")
+		}
+	}
+}
+
+func TestE2EWithProcessFileNameFluentd(t *testing.T) {
+
+	for i := 0; i < 30; i++ {
+		time.Sleep(1 * time.Second)
+
+		metrics, err := get("http://localhost:29256/metrics")
+		if err != nil {
+			t.Errorf("HttpClient.Get = %v", err)
+		}
+
+		log.Info(metrics)
+
+		// td_agent_cpu_time
+		if !regexp.MustCompile(`td_agent_cpu_time\{id="from_fluentd"\} `).MatchString(metrics) {
+			t.Error(`td_agent_cpu_time{id="from_fluentd"} doesn't match`)
+		}
+
+		// td_agent_resident_memory_usage
+		if !regexp.MustCompile(`td_agent_resident_memory_usage\{id="from_fluentd"\} `).MatchString(metrics) {
+			t.Error(`td_agent_resident_memory_usage{id="from_fluentd"} doesn't match`)
+		}
+
+		// td_agent_virtual_memory_usage
+		if !regexp.MustCompile(`td_agent_virtual_memory_usage\{id="from_fluentd"\} `).MatchString(metrics) {
+			t.Error(`td_agent_virtual_memory_usage{id="from_fluentd"} doesn't match`)
+		}
+
+		// td_agent_up
+		if !regexp.MustCompile("td_agent_up 1").MatchString(metrics) {
+			t.Error("td_agent_up doesn't match")
+		}
+	}
+}
+
+func TestE2EWithProcessFileNameTDAgent(t *testing.T) {
+
+	for i := 0; i < 30; i++ {
+		time.Sleep(1 * time.Second)
+
+		metrics, err := get("http://localhost:39256/metrics")
+		if err != nil {
+			t.Errorf("HttpClient.Get = %v", err)
+		}
+
+		log.Info(metrics)
+
+		// td_agent_cpu_time
+		if !regexp.MustCompile(`td_agent_cpu_time\{id="from_td_agent"\} `).MatchString(metrics) {
+			t.Error(`td_agent_cpu_time{id="from_td_agent"} doesn't match`)
+		}
+
+		// td_agent_resident_memory_usage
+		if !regexp.MustCompile(`td_agent_resident_memory_usage\{id="from_td_agent"\} `).MatchString(metrics) {
+			t.Error(`td_agent_resident_memory_usage{id="from_td_agent"} doesn't match`)
+		}
+
+		// td_agent_virtual_memory_usage
+		if !regexp.MustCompile(`td_agent_virtual_memory_usage\{id="from_td_agent"\} `).MatchString(metrics) {
+			t.Error(`td_agent_virtual_memory_usage{id="from_td_agent"} doesn't match`)
+		}
+
+		// td_agent_up
+		if !regexp.MustCompile("td_agent_up 1").MatchString(metrics) {
 			t.Error("td_agent_up doesn't match")
 		}
 	}

--- a/td-agent_exporter_test.go
+++ b/td-agent_exporter_test.go
@@ -149,7 +149,7 @@ func TestE2EWithoutProcessNamePrefix(t *testing.T) {
 
 		metrics, err := get("http://localhost:9256/metrics")
 		if err != nil {
-			t.Error("HttpClient.Get = %v", err)
+			t.Errorf("HttpClient.Get = %v", err)
 		}
 
 		log.Info(metrics)
@@ -210,7 +210,7 @@ func TestE2EWithProcessNamePrefix(t *testing.T) {
 
 		metrics, err := get("http://localhost:19256/metrics")
 		if err != nil {
-			t.Error("HttpClient.Get = %v", err)
+			t.Errorf("HttpClient.Get = %v", err)
 		}
 
 		log.Info(metrics)

--- a/td-agent_exporter_test.go
+++ b/td-agent_exporter_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -11,6 +12,42 @@ import (
 )
 
 // unit test
+func TestParseArgDefaultValues(t *testing.T) {
+	parseTargetArgs := []string{}
+	flag.CommandLine.Parse(parseTargetArgs)
+
+	if *listenAddress != "9256" {
+		t.Errorf("listenAddress default value want %v but %v.", "9256", *listenAddress)
+	}
+	if *metricsPath != "/metrics" {
+		t.Errorf("metricsPath default value want %v but %v.", "/metrics", *metricsPath)
+	}
+	if *processFileName != "ruby" {
+		t.Errorf("processFileName default value want %v but %v.", "ruby", *processFileName)
+	}
+	if *processNamePrefix != "" {
+		t.Errorf("processNamePrefix default value want %v but %v.", "", *processNamePrefix)
+	}
+}
+
+func TestParseArgSpecifiedValues(t *testing.T) {
+	parseTargetArgs := []string{"-web.listen-address", "19256", "-web.telemetry-path", "/metricsPath", "-fluentd.process_file_name", "td-agent", "-fluentd.process_name_prefix", "prefix"}
+	flag.CommandLine.Parse(parseTargetArgs)
+
+	if *listenAddress != "19256" {
+		t.Errorf("listenAddress default value want %v but %v.", "19256", *listenAddress)
+	}
+	if *metricsPath != "/metricsPath" {
+		t.Errorf("metricsPath default value want %v but %v.", "/metricsPath", *metricsPath)
+	}
+	if *processFileName != "td-agent" {
+		t.Errorf("processFileName default value want %v but %v.", "td-agent", *processFileName)
+	}
+	if *processNamePrefix != "prefix" {
+		t.Errorf("processNamePrefix default value want %v but %v.", "prefix", *processNamePrefix)
+	}
+}
+
 func TestUnitFilterWithoutProcessNamePrefix(t *testing.T) {
 	lines := []string{
 		"UID        PID  PPID  C STIME TTY          TIME CMD",


### PR DESCRIPTION
## Abstract

- Add process file name option to td-agent_exporter for various environments.

## Background 

In our td-agent cluster, td-agent_exporter does't get metrics.

- Environment
  - OS: CentOS7.3
  - Version: td-agent3.1.1 / Fluentd 1.1.3
  - td-agent processes are being exectuted from supervisord, standalone worker mode.

Because, td-agent_exporter executes ps command by "-C ruby", td-agent processes are not matched.

```
$ ps -C ruby -f
UID         PID   PPID  C STIME TTY          TIME CMD
```

If process file name specified "td-agent", td-agent processes are matched.

```
$ ps -C td-agent -f
UID         PID   PPID  C STIME TTY          TIME CMD
td-agent  48368  50994  2  4月25 ?      00:30:38 worker:fluentd_aggregation_receiver01
td-agent  42646  50994  2  4月25 ?      00:30:38 worker:fluentd_aggregation_receiver02
td-agent  43008  50994  2  4月25 ?      00:30:38 worker:fluentd_aggregation_receiver03
```

## Update point

- Add "fluentd.process_file_name" option, default value "ruby".
  - Original users can use continuously with no option update.
