### PR TITLE
corresponds to td-agent4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,37 +47,37 @@ e2etest:
 e2etest_setup:
 	# td-agent
 	yum install -y sudo
-	curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent2.sh | sh
+	curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
 	cp /go/src/github.com/matsumana/td-agent_exporter/_test/*.conf /etc/td-agent
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_4.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_4.pid --config /etc/td-agent/td-agent_4.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_5.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_5.pid --config /etc/td-agent/td-agent_5.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_6.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_6.pid --config /etc/td-agent/td-agent_6.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_7.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_7.pid --config /etc/td-agent/td-agent_7.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_8.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_8.pid --config /etc/td-agent/td-agent_8.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_9.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_9.pid --config /etc/td-agent/td-agent_9.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_10.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_10.pid --config /etc/td-agent/td-agent_10.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_11.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_11.pid --config /etc/td-agent/td-agent_11.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_12.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_12.pid --config /etc/td-agent/td-agent_12.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_13.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_13.pid --config /etc/td-agent/td-agent_13.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_a.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_a.pid --config /etc/td-agent/td-agent_a.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_b.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_b.pid --config /etc/td-agent/td-agent_b.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_c.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_c.pid --config /etc/td-agent/td-agent_c.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_d.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_d.pid --config /etc/td-agent/td-agent_d.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_e.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_e.pid --config /etc/td-agent/td-agent_e.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_f.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_f.pid --config /etc/td-agent/td-agent_f.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_g.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_g.pid --config /etc/td-agent/td-agent_g.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_h.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_h.pid --config /etc/td-agent/td-agent_h.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_i.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_i.pid --config /etc/td-agent/td-agent_i.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_j.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_j.pid --config /etc/td-agent/td-agent_j.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_k.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_k.pid --config /etc/td-agent/td-agent_k.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_l.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_l.pid --config /etc/td-agent/td-agent_l.conf
-	/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_m.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_m.pid --config /etc/td-agent/td-agent_m.conf
-	/opt/td-agent/embedded/bin/fluentd --use-v1-config --config /etc/td-agent/td-agent_from_fluent.conf --no-supervisor &
-	/usr/sbin/td-agent --use-v1-config --config /etc/td-agent/td-agent_from_td_agent.conf --no-supervisor &
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_3.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_4.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_4.pid --config /etc/td-agent/td-agent_4.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_5.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_5.pid --config /etc/td-agent/td-agent_5.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_6.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_6.pid --config /etc/td-agent/td-agent_6.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_7.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_7.pid --config /etc/td-agent/td-agent_7.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_8.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_8.pid --config /etc/td-agent/td-agent_8.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_9.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_9.pid --config /etc/td-agent/td-agent_9.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_10.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_10.pid --config /etc/td-agent/td-agent_10.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_11.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_11.pid --config /etc/td-agent/td-agent_11.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_12.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_12.pid --config /etc/td-agent/td-agent_12.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_13.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_13.pid --config /etc/td-agent/td-agent_13.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_a.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_a.pid --config /etc/td-agent/td-agent_a.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_b.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_b.pid --config /etc/td-agent/td-agent_b.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_c.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_c.pid --config /etc/td-agent/td-agent_c.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_d.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_d.pid --config /etc/td-agent/td-agent_d.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_e.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_e.pid --config /etc/td-agent/td-agent_e.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_f.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_f.pid --config /etc/td-agent/td-agent_f.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_g.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_g.pid --config /etc/td-agent/td-agent_g.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_h.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_h.pid --config /etc/td-agent/td-agent_h.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_i.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_i.pid --config /etc/td-agent/td-agent_i.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_j.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_j.pid --config /etc/td-agent/td-agent_j.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_k.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_k.pid --config /etc/td-agent/td-agent_k.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_l.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_l.pid --config /etc/td-agent/td-agent_l.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_m.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_m.pid --config /etc/td-agent/td-agent_m.conf
+	/opt/td-agent/binfluentd --setup /etc/td-agent --use-v1-config --config /etc/td-agent/td-agent_from_fluent.conf --no-supervisor &
+	/opt/td-agent/bin/fluentd --setup /etc/td-agent --use-v1-config --config /etc/td-agent/td-agent_from_td_agent.conf --no-supervisor &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug -web.listen-address=19256 -fluentd.process_name_prefix=foo &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug -web.listen-address=29256 -fluentd.process_name_prefix=from -fluentd.process_file_name=fluentd &

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ e2etest_setup:
 	curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
 	cp /go/src/github.com/matsumana/td-agent_exporter/_test/*.conf /etc/td-agent
 	mkdir ${PID_DIR}
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent.pid
+	env FLUENT_CONF=/etc/td-agent/td-agent.conf /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent.pid
 	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf
 	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf
 	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BIN_DIR=bin
 BUILD_GOLANG_VERSION=1.8.3
 CENTOS_VERSION=7
 GITHUB_USERNAME=matsumana
+PID_DIR=/var/run/td-agent
 
 .PHONY : build-with-docker
 build-with-docker:
@@ -49,33 +50,34 @@ e2etest_setup:
 	yum install -y sudo
 	curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
 	cp /go/src/github.com/matsumana/td-agent_exporter/_test/*.conf /etc/td-agent
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_4.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_4.pid --config /etc/td-agent/td-agent_4.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_5.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_5.pid --config /etc/td-agent/td-agent_5.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_6.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_6.pid --config /etc/td-agent/td-agent_6.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_7.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_7.pid --config /etc/td-agent/td-agent_7.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_8.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_8.pid --config /etc/td-agent/td-agent_8.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_9.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_9.pid --config /etc/td-agent/td-agent_9.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_10.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_10.pid --config /etc/td-agent/td-agent_10.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_11.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_11.pid --config /etc/td-agent/td-agent_11.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_12.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_12.pid --config /etc/td-agent/td-agent_12.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_13.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_13.pid --config /etc/td-agent/td-agent_13.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_a.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_a.pid --config /etc/td-agent/td-agent_a.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_b.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_b.pid --config /etc/td-agent/td-agent_b.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_c.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_c.pid --config /etc/td-agent/td-agent_c.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_d.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_d.pid --config /etc/td-agent/td-agent_d.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_e.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_e.pid --config /etc/td-agent/td-agent_e.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_f.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_f.pid --config /etc/td-agent/td-agent_f.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_g.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_g.pid --config /etc/td-agent/td-agent_g.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_h.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_h.pid --config /etc/td-agent/td-agent_h.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_i.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_i.pid --config /etc/td-agent/td-agent_i.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_j.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_j.pid --config /etc/td-agent/td-agent_j.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_k.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_k.pid --config /etc/td-agent/td-agent_k.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_l.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_l.pid --config /etc/td-agent/td-agent_l.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_m.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_m.pid --config /etc/td-agent/td-agent_m.conf
+	mkdir ${PID_DIR}
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent.pid
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_4.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_4.pid --config /etc/td-agent/td-agent_4.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_5.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_5.pid --config /etc/td-agent/td-agent_5.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_6.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_6.pid --config /etc/td-agent/td-agent_6.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_7.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_7.pid --config /etc/td-agent/td-agent_7.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_8.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_8.pid --config /etc/td-agent/td-agent_8.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_9.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_9.pid --config /etc/td-agent/td-agent_9.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_10.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_10.pid --config /etc/td-agent/td-agent_10.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_11.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_11.pid --config /etc/td-agent/td-agent_11.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_12.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_12.pid --config /etc/td-agent/td-agent_12.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_13.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_13.pid --config /etc/td-agent/td-agent_13.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_a.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_a.pid --config /etc/td-agent/td-agent_a.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_b.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_b.pid --config /etc/td-agent/td-agent_b.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_c.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_c.pid --config /etc/td-agent/td-agent_c.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_d.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_d.pid --config /etc/td-agent/td-agent_d.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_e.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_e.pid --config /etc/td-agent/td-agent_e.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_f.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_f.pid --config /etc/td-agent/td-agent_f.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_g.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_g.pid --config /etc/td-agent/td-agent_g.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_h.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_h.pid --config /etc/td-agent/td-agent_h.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_i.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_i.pid --config /etc/td-agent/td-agent_i.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_j.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_j.pid --config /etc/td-agent/td-agent_j.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_k.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_k.pid --config /etc/td-agent/td-agent_k.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_l.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_l.pid --config /etc/td-agent/td-agent_l.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_m.log --use-v1-config --group td-agent --daemon ${PID_DIR}/td-agent_m.pid --config /etc/td-agent/td-agent_m.conf
 	/opt/td-agent/bin/fluentd --use-v1-config --config /etc/td-agent/td-agent_from_fluent.conf --no-supervisor &
 	/usr/sbin/td-agent --config /etc/td-agent/td-agent_from_td_agent.conf --no-supervisor &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug &

--- a/Makefile
+++ b/Makefile
@@ -49,35 +49,35 @@ e2etest_setup:
 	yum install -y sudo
 	curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
 	cp /go/src/github.com/matsumana/td-agent_exporter/_test/*.conf /etc/td-agent
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_3.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_4.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_4.pid --config /etc/td-agent/td-agent_4.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_5.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_5.pid --config /etc/td-agent/td-agent_5.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_6.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_6.pid --config /etc/td-agent/td-agent_6.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_7.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_7.pid --config /etc/td-agent/td-agent_7.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_8.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_8.pid --config /etc/td-agent/td-agent_8.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_9.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_9.pid --config /etc/td-agent/td-agent_9.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_10.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_10.pid --config /etc/td-agent/td-agent_10.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_11.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_11.pid --config /etc/td-agent/td-agent_11.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_12.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_12.pid --config /etc/td-agent/td-agent_12.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_13.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_13.pid --config /etc/td-agent/td-agent_13.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_a.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_a.pid --config /etc/td-agent/td-agent_a.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_b.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_b.pid --config /etc/td-agent/td-agent_b.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_c.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_c.pid --config /etc/td-agent/td-agent_c.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_d.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_d.pid --config /etc/td-agent/td-agent_d.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_e.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_e.pid --config /etc/td-agent/td-agent_e.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_f.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_f.pid --config /etc/td-agent/td-agent_f.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_g.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_g.pid --config /etc/td-agent/td-agent_g.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_h.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_h.pid --config /etc/td-agent/td-agent_h.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_i.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_i.pid --config /etc/td-agent/td-agent_i.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_j.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_j.pid --config /etc/td-agent/td-agent_j.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_k.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_k.pid --config /etc/td-agent/td-agent_k.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_l.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_l.pid --config /etc/td-agent/td-agent_l.conf
-	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_m.log --setup /etc/td-agent --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_m.pid --config /etc/td-agent/td-agent_m.conf
-	/opt/td-agent/binfluentd --setup /etc/td-agent --use-v1-config --config /etc/td-agent/td-agent_from_fluent.conf --no-supervisor &
-	/opt/td-agent/bin/fluentd --setup /etc/td-agent --use-v1-config --config /etc/td-agent/td-agent_from_td_agent.conf --no-supervisor &
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_4.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_4.pid --config /etc/td-agent/td-agent_4.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_5.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_5.pid --config /etc/td-agent/td-agent_5.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_6.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_6.pid --config /etc/td-agent/td-agent_6.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_7.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_7.pid --config /etc/td-agent/td-agent_7.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_8.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_8.pid --config /etc/td-agent/td-agent_8.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_9.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_9.pid --config /etc/td-agent/td-agent_9.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_10.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_10.pid --config /etc/td-agent/td-agent_10.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_11.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_11.pid --config /etc/td-agent/td-agent_11.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_12.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_12.pid --config /etc/td-agent/td-agent_12.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_13.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_13.pid --config /etc/td-agent/td-agent_13.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_a.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_a.pid --config /etc/td-agent/td-agent_a.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_b.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_b.pid --config /etc/td-agent/td-agent_b.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_c.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_c.pid --config /etc/td-agent/td-agent_c.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_d.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_d.pid --config /etc/td-agent/td-agent_d.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_e.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_e.pid --config /etc/td-agent/td-agent_e.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_f.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_f.pid --config /etc/td-agent/td-agent_f.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_g.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_g.pid --config /etc/td-agent/td-agent_g.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_h.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_h.pid --config /etc/td-agent/td-agent_h.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_i.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_i.pid --config /etc/td-agent/td-agent_i.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_j.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_j.pid --config /etc/td-agent/td-agent_j.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_k.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_k.pid --config /etc/td-agent/td-agent_k.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_l.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_l.pid --config /etc/td-agent/td-agent_l.conf
+	/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_m.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_m.pid --config /etc/td-agent/td-agent_m.conf
+	/opt/td-agent/bin/fluentd --use-v1-config --config /etc/td-agent/td-agent_from_fluent.conf --no-supervisor &
+	/usr/sbin/td-agent --config /etc/td-agent/td-agent_from_td_agent.conf --no-supervisor &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug -web.listen-address=19256 -fluentd.process_name_prefix=foo &
 	/go/src/github.com/matsumana/td-agent_exporter/bin/td-agent_exporter-*.linux-amd64/td-agent_exporter -log.level=debug -web.listen-address=29256 -fluentd.process_name_prefix=from -fluentd.process_file_name=fluentd &

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ example setting of td-agent __without__ process_name
 
   ```
   UID        PID  PPID  C STIME TTY          TIME CMD
-  root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid --config /etc/td-agent/td-agent.conf
-  root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid --config /etc/td-agent/td-agent.conf
+  root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid --config /etc/td-agent/td-agent.conf
+  root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid --config /etc/td-agent/td-agent.conf
   ```
 
 - Exported metrics example

--- a/td-agent_exporter.go
+++ b/td-agent_exporter.go
@@ -23,7 +23,7 @@ var (
 	processFileName   = flag.String("fluentd.process_file_name", "ruby", "fluentd's process file name.")
 	processNamePrefix = flag.String("fluentd.process_name_prefix", "", "fluentd's process_name prefix.")
 
-	processNameRegex       = regexp.MustCompile(`\s/usr/sbin/td-agent\s*`)
+	processNameRegex       = regexp.MustCompile(`\s/opt/td-agent/bin/fluentd\s*`)
 	tdAgentPathRegex       = regexp.MustCompile("\\s" + strings.Replace(tdAgentLaunchCommand, " ", "\\s", -1) + "(.+)?\\s*")
 	configFileNameRegex    = regexp.MustCompile(`\s(-c|--config)\s.*/(.+)\.conf\s*`)
 	processNamePrefixRegex = regexp.MustCompile(`\sworker:(.+)?\s*`)
@@ -32,7 +32,7 @@ var (
 const (
 	// Can't use '-' for the metric name
 	namespace            = "td_agent"
-	tdAgentLaunchCommand = "/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent "
+	tdAgentLaunchCommand = "/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd "
 )
 
 type Exporter struct {

--- a/td-agent_exporter_test.go
+++ b/td-agent_exporter_test.go
@@ -52,14 +52,14 @@ func TestUnitFilterWithoutProcessNamePrefix(t *testing.T) {
 	lines := []string{
 		"UID        PID  PPID  C STIME TTY          TIME CMD",
 		"vagrant   1342  1338  0 04:03 pts/0    00:00:03 /home/vagrant/local/ruby-2.3/bin/ruby -Eascii-8bit:ascii-8bit /home/vagrant/local/ruby-2.3/bin/fluentd -c ./fluent/fluent.conf -vv --under-supervisor",
-		"td-agent  2596     1  0 07:08 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
-		"td-agent  2599  2596  0 07:08 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
-		"root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
-		"root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
-		"root      2463     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
-		"root      2466  2463  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
-		"root      2476     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
-		"root      2479  2476  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
+		"td-agent  2596     1  0 07:08 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
+		"td-agent  2599  2596  0 07:08 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
+		"root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
+		"root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
+		"root      2463     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
+		"root      2466  2463  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
+		"root      2476     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
+		"root      2479  2476  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
 		"root      2489     1  0 07:07 ?        00:00:00 supervisor:foo_a",
 		"root      2492  2489  0 07:07 ?        00:00:00 worker:foo_a",
 		"root      2502     1  0 07:07 ?        00:00:00 supervisor:foo_b",
@@ -82,14 +82,14 @@ func TestUnitFilterWithProcessNamePrefix(t *testing.T) {
 	lines := []string{
 		"UID        PID  PPID  C STIME TTY          TIME CMD",
 		"vagrant   1342  1338  0 04:03 pts/0    00:00:03 /home/vagrant/local/ruby-2.3/bin/ruby -Eascii-8bit:ascii-8bit /home/vagrant/local/ruby-2.3/bin/fluentd -c ./fluent/fluent.conf -vv --under-supervisor",
-		"td-agent  2596     1  0 07:08 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
-		"td-agent  2599  2596  0 07:08 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
-		"root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
-		"root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
-		"root      2463     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
-		"root      2466  2463  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
-		"root      2476     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
-		"root      2479  2476  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
+		"td-agent  2596     1  0 07:08 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
+		"td-agent  2599  2596  0 07:08 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
+		"root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
+		"root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
+		"root      2463     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
+		"root      2466  2463  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
+		"root      2476     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
+		"root      2479  2476  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
 		"root      2489     1  0 07:07 ?        00:00:00 supervisor:foo_a",
 		"root      2492  2489  0 07:07 ?        00:00:00 worker:foo_a",
 		"root      2502     1  0 07:07 ?        00:00:00 supervisor:foo_b",
@@ -110,14 +110,14 @@ func TestUnitFilterWithProcessNamePrefix(t *testing.T) {
 
 func TestUnitResolveLabelWithConfigFileName(t *testing.T) {
 	lines := []string{
-		"td-agent  2596     1  0 07:08 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
-		"td-agent  2599  2596  0 07:08 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
-		"root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
-		"root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
-		"root      2463     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
-		"root      2466  2463  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
-		"root      2476     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
-		"root      2479  2476  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
+		"td-agent  2596     1  0 07:08 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
+		"td-agent  2599  2596  0 07:08 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid",
+		"root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
+		"root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf",
+		"root      2463     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
+		"root      2466  2463  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_2.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf",
+		"root      2476     1  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
+		"root      2479  2476  0 07:07 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --config /etc/td-agent/td-agent_3.conf --log /var/log/td-agent/td-agent_3.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid",
 	}
 
 	processName := ""
@@ -132,22 +132,22 @@ func TestUnitResolveLabelWithConfigFileName(t *testing.T) {
 	}
 
 	if value, ok := labels["default"]; !ok &&
-		value == "/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid" {
+		value == "/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid" {
 		t.Error("labels `default` doesn't exist")
 	}
 
 	if value, ok := labels["td-agent_1"]; !ok &&
-		value == "/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf" {
+		value == "/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_1.pid --config /etc/td-agent/td-agent_1.conf" {
 		t.Error("labels `td-agent_1` doesn't exist")
 	}
 
 	if value, ok := labels["td-agent_2"]; !ok &&
-		value == "/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf" {
+		value == "/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_2.pid --config /etc/td-agent/td-agent_2.conf" {
 		t.Error("labels `td-agent_2` doesn't exist")
 	}
 
 	if value, ok := labels["td-agent_3"]; !ok &&
-		value == "/opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf" {
+		value == "/opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent_1.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent_3.pid --config /etc/td-agent/td-agent_3.conf" {
 		t.Error("labels `td-agent_3` doesn't exist")
 	}
 }
@@ -242,7 +242,7 @@ func TestE2EWithoutProcessNamePrefix(t *testing.T) {
 		t.Error("Process from /opt/td-agent/embedded/bin/fluentd shouldn't match")
 	}
 	if regexp.MustCompile(`td_agent_cpu_time\{id="from_td-agent"\} `).MatchString(metrics) {
-		t.Error("Process from /usr/sbin/td-agent shouldn't match")
+		t.Error("Process from /opt/td-agent/bin/fluentd shouldn't match")
 	}
 }
 

--- a/td-agent_exporter_test.go
+++ b/td-agent_exporter_test.go
@@ -356,18 +356,18 @@ func get(url string) (string, error) {
 
 	response, err := http.Get(url)
 	if err != nil {
-		log.Error("http.Get = %v", err)
+		log.Errorf("http.Get = %v", err)
 		return "", err
 	}
 	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		log.Error("ioutil.ReadAll = %v", err)
+		log.Errorf("ioutil.ReadAll = %v", err)
 		return "", err
 	}
 	if response.StatusCode != 200 {
-		log.Error("response.StatusCode = %v", response.StatusCode)
+		log.Errorf("response.StatusCode = %v", response.StatusCode)
 		return "", err
 	}
 


### PR DESCRIPTION
Hi matsumana!
Thank you for your great exporter.

It seems to support td-agent 2 but [the latest td-agent is 4](https://github.com/fluent-plugins-nursery/td-agent-builder).
So I want to use it for td-agent4.

td-agent4's process is deferent from 2 (without `process_name` case)
```
# td-agent2 (from its README)
UID        PID  PPID  C STIME TTY          TIME CMD
root      2450     1  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid --config /etc/td-agent/td-agent.conf
root      2453  2450  0 07:07 ?        00:00:00 /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent --log /var/log/td-agent/td-agent.log --use-v1-config --group td-agent --daemon /var/run/td-agent/td-agent.pid --config /etc/td-agent/td-agent.conf

# td-agent4 (Installed to CentOS7 with https://docs.fluentd.org/installation/install-by-rpm#red-hat-centos )
UID        PID  PPID  C STIME TTY          TIME CMD
td-agent  3807     1  0 15:12 ?        00:00:00 /opt/td-agent/bin/ruby /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --daemon /var/run/td-agent/td-agent.pid
td-agent  3810  3807  0 15:12 ?        00:00:01 /opt/td-agent/bin/ruby -Eascii-8bit:ascii-8bit /opt/td-agent/bin/fluentd --log /var/log/td-agent/td-agent.log --daemon /var/run/td-agent/td-agent.pid --under-supervisor
```

So we cannot find process with  `\s/usr/sbin/td-agent\s*`.
https://github.com/matsumana/td-agent_exporter/blob/55d8523a3a518cbf377f58969b98877e84152d0b/td-agent_exporter.go#L26

Please check it!